### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dynamic inference with PyTorch.
 
 You need to clone the repo with recursive submodules.
 
-`git clone --recurse-submodules git@github.com:facebookexperimental/protoquant.git`
+`git clone --recurse-submodules https://github.com/facebookexperimental/protoquant.git`
 
 If you forget to, you can always fix this using [this
 trick](https://gist.github.com/cnlohr/04de6edd3e2a75face0a68c53be2017e)


### PR DESCRIPTION
Made the file a readme so it renders in a prettier way on github and also changed `git clone --recurse-submodules git@github.com:facebookexperimental/protoquant.git` because this requires setting up an ssh key so this fix removes this error

```
(segment) ubuntu@ip-172-31-38-220:~$ git clone --recurse-submodules git@github.com:facebookexperimental/protoquant.git
Cloning into 'protoquant'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
```
