### PR TITLE
adding safe_int_mm

### DIFF
--- a/ao_experimental/quant_primitives.py
+++ b/ao_experimental/quant_primitives.py
@@ -1,0 +1,43 @@
+import torch
+from torch import _dynamo
+
+def safe_int_mm(x_int8: torch.Tensor, w_int8: torch.Tensor):
+    """
+    This function wraps torch._int_mm and avoids several undesirable behaviors of the function for certain inputs while still 
+    returning correct results and being torch.compiled in a performant way.
+
+    Assumes both tensors have dimension of 2 and have dtype torch.int8
+    
+    Note: no error checking for torch.compiled path, if x_int8.shape = [i, j] and j<=16 then the triton kernel
+    will silently give incorrect results
+
+    Args:
+        x_int8: the first tensor to be multiplied
+        w_int8: the second tensor to be multiplied
+
+    Return:
+        the output tensor of the matmul with dtype torch.int32 and device matching that of the inputs
+    """
+
+    # torch.compile path
+    if torch._dynamo.is_compiling():
+        return torch._int_mm(x_int8, w_int8)
+    
+    # error checking for cublas path    
+    device_cpu = 'cpu' in [w_int8.device.type, x_int8.device.type]
+    # with x_int8.shape = [i,j] and w_int8.shape = [j,k]
+    i_is_strictly_greater_than_16 = (x_int8.shape[0] > 16)
+    j_is_nonzero_multiple_of_8 = ((x_int8.shape[1] % 8 == 0) and (x_int8.shape[1] > 0)) 
+    k_is_nonzero_multiple_of_8 = ((w_int8.shape[1] % 8 == 0) and (w_int8.shape[1] > 0))
+    bad_dimensions_for_cublas = not (i_is_strictly_greater_than_16 and j_is_nonzero_multiple_of_8 and k_is_nonzero_multiple_of_8)
+
+    if device_cpu or bad_dimensions_for_cublas:
+        # fallback path
+        return torch.matmul(x_int8.cpu().to(torch.int32), w_int8.cpu().to(torch.int32)).to(x_int8.device.type)
+
+    # cublas paths
+    if not w_int8.is_contiguous(): # silently gives incorrect result without this
+        w_int8 = w_int8.contiguous()
+    if (not x_int8.is_contiguous()) and (x_int8.shape[0] % 8 != 0): # gives cryptic error without this           
+        x_int8 = x_int8.contiguous() # (it seems the transpose makes cublas check the above j constraint on i)
+    return torch._int_mm(x_int8, w_int8)

--- a/ao_experimental/test_quant_primitives.py
+++ b/ao_experimental/test_quant_primitives.py
@@ -1,0 +1,90 @@
+import torch
+
+import unittest
+from quant_primitives import safe_int_mm
+
+class TestSafeIntMM(unittest.TestCase):
+    """ 
+    Tests the safe_int_mm functionality/correctness across a variety of input cases  
+    """
+    test_shapes = (
+        # ((x_shape), (w_shape))
+        ((8, 17), (17, 8)), # break cublas but not triton (fallback)
+        ((17, 24), (24, 8)), # smallest test that doesn't need fallback
+        ((1536, 1536), (1536, 1536)),
+        ((17, 4096), (4096, 1536)),
+        # ((17, 8), (8, 8)), # breaks triton but not cublas 
+        # note: this last isn't tested since triton path doesn't have the fallback option for perf reasons,
+        # so the error is expected
+    )
+
+    def _test_safe_int_mm_impl(self, x, w):
+        y = safe_int_mm(x, w)
+        y_ref = torch.matmul(x.to(torch.int32).cpu(),w.to(torch.int32).cpu()).to(x.device)
+        torch.testing.assert_close(
+            y_ref, y, atol=0, rtol=0,
+            msg = r"failed for shape {} and {}".format(x.shape, w.shape)
+        )
+
+        if x.device.type == 'cuda':
+            trit_safe_int_mm = torch.compile(safe_int_mm, mode='max-autotune')
+            y_triton = trit_safe_int_mm(x, w)
+            torch.testing.assert_close(
+                y_ref, y_triton, atol=0, rtol=0, 
+                msg = r"failed for shape {} and {}".format(x.shape, w.shape)
+                )
+
+    def test_safe_int_mm_cuda(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape, dtype = torch.int8, device='cuda')
+            w = torch.randint(-128, 127, w_shape, dtype = torch.int8, device='cuda')
+            self._test_safe_int_mm_impl(x, w)
+
+    def test_safe_int_mm_cpu(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape, dtype = torch.int8, device='cpu')
+            w = torch.randint(-128, 127, w_shape, dtype = torch.int8, device='cpu')
+            self._test_safe_int_mm_impl(x, w)
+
+    def test_safe_int_mm_cuda_non_contiguous_mat2(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape, dtype = torch.int8, device='cuda')
+            w = torch.randint(-128, 127, w_shape[::-1], dtype = torch.int8, device='cuda').transpose(0,1)
+            assert not w.is_contiguous()
+            self._test_safe_int_mm_impl(x, w)
+
+    def test_safe_int_mm_cpu_non_contiguous_mat2(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape, dtype = torch.int8, device='cpu')
+            w = torch.randint(-128, 127, w_shape[::-1], dtype = torch.int8, device='cpu').transpose(0,1)
+            assert not w.is_contiguous()
+            self._test_safe_int_mm_impl(x, w)
+
+    def test_safe_int_mm_cuda_non_contiguous_input(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape[::-1], dtype = torch.int8, device='cuda').transpose(0,1)
+            w = torch.randint(-128, 127, w_shape, dtype = torch.int8, device='cuda')
+            assert not x.is_contiguous()
+            self._test_safe_int_mm_impl(x, w)
+
+    def test_safe_int_mm_cpu_non_contiguous_input(self):
+        for x_shape, w_shape in self.test_shapes:
+            x = torch.randint(-128, 127, x_shape[::-1], dtype = torch.int8, device='cpu').transpose(0,1)
+            w = torch.randint(-128, 127, w_shape, dtype = torch.int8, device='cpu')
+            assert not x.is_contiguous()
+            self._test_safe_int_mm_impl(x, w)
+
+# class TestQuantInt8MatMul(unittest.TestCase):
+
+#     def _test_quant_int8_matmul_impl(self,
+#         x_vals_int8,
+#         x_scale,
+#         x_zp,
+#         w_vals_int8_t,
+#         w_scales,
+#         out_dtype=torch.float32,):
+#         w_vals_int8_t_sums_int64 = w_vals_int8_t.sum(dim=0)
+#         x_scale = 
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #22
* #21
* #20
* #18
* __->__ #17

Summary: this is intended as a wrapper for torch._int_mm which
has a number of characteristics that make it difficult to use/debug.
This wrapped version:
1) falls back to a cpu compatible path if ran on cpu
2) short circuits to normal torch._int_mm if it detects torch compilation
to avoid perf degredation,
3) error checks tensor dimensions to avoid regions where cublas errors
and uses fallback instead
4) calls contiguous when w is non contiguous to avoid cublas silently
returning nonsense data
5) calls contiguous when x has a combination of being non-contiguous &
dim 0 is not a multiple of 8 which avoids a cryptic cublas error
*note* the torch compiled short circuit path doesn't have any error
checking so if that path is taken with tensors whose inner
multiplication dimension is <= 16 then it will error

triton graph of safe_int_mm:
==== __compiled_fn_0 =====
 <eval_with_key>.2 class GraphModule(torch.nn.Module):
    def forward(self, L_x_int8_ : torch.Tensor, L_w_int8_ : torch.Tensor):
        l_x_int8_ = L_x_int8_
        l_w_int8_ = L_w_int8_

        # File: /fsx/users/cdhernandez/protoquant/ao_experimental/quant_primitives.py:24, code: return torch._int_mm(x_int8, w_int8)
        _int_mm = torch._int_mm(l_x_int8_, l_w_int8_);  l_x_int8_ = l_w_int8_ = None
        return (_int_mm,)

[2023-05-10 00:32:08,655] torch._dynamo.output_graph.__graph: [DEBUG] TRACED GRAPH
 __compiled_fn_0 <eval_with_key>.2 opcode         name       target                                                      args                    kwargs
-------------  ---------  ----------------------------------------------------------  ----------------------  --------
placeholder    l_x_int8_  L_x_int8_                                                   ()                      {}
placeholder    l_w_int8_  L_w_int8_                                                   ()                      {}
call_function  _int_mm    <built-in method _int_mm of type object at 0x7fe27c3c48a0>  (l_x_int8_, l_w_int8_)  {}
output         output     output                                                      ((_int_mm,),)           {}

Test Plan: python test_quant_primitives.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D45757849](https://our.internmc.facebook.com/intern/diff/D45757849)