### PR TITLE
protoquant adding dynamically_quantize_per_channel

### DIFF
--- a/ao_experimental/test_quant_primitives.py
+++ b/ao_experimental/test_quant_primitives.py
@@ -1,10 +1,74 @@
 import torch
 
 import unittest
-from itertools import cycle as cycle
-from quant_primitives import dynamically_quantize_per_tensor, safe_int_mm
+from quant_primitives import dynamically_quantize_per_tensor, safe_int_mm, dynamically_quantize_per_channel
+from itertools import cycle
 
 torch.manual_seed(0)
+
+class TestPerChannelQuantization(unittest.TestCase):
+    """ 
+    Tests the dynamically_quantize_per_channel function across a variety of input cases and ensures numerics match ao version
+    """
+    shapes = (
+        (1, 200, 200),
+        (5, 5),
+        (2, 8, 32 , 32),
+        (32, 16, 64, 64),
+    )
+    def _test_dynamically_quantize_per_channel_impl(self, device, quant_min = -128, quant_max = 127, target_dtype = torch.int8):
+        f_dtypes = cycle([torch.float16, torch.float32, torch.float64])
+        transposes = cycle([True, False])
+        for x_shape in self.shapes:
+            for axis in range(len(x_shape)):
+                transp = next(transposes)
+                f_dtype = next(f_dtypes)
+                x = torch.randn(x_shape, device=device, dtype = f_dtype)*1000
+                if transp:
+                    x = x.transpose(0, -1)
+                
+                x_int8, scales, zero_points = dynamically_quantize_per_channel(x, quant_min, quant_max, target_dtype, axis=axis)
+            
+
+                q_dtype = torch.quint8 if target_dtype == torch.uint8 else torch.qint8
+
+                obs = torch.ao.quantization.PerChannelMinMaxObserver(ch_axis = axis, dtype = q_dtype, qscheme = torch.per_channel_symmetric, reduce_range = False)
+                obs(x)
+                ref_scales, ref_zero_points = obs.calculate_qparams()
+                ref_scales, ref_zero_points = ref_scales.to(x.device), ref_zero_points.to(x.device)
+                torch.testing.assert_close(scales.to(torch.float32), ref_scales)
+                torch.testing.assert_close(zero_points, ref_zero_points, atol=0, rtol=0)
+
+                x_q_int_repr = torch.quantize_per_channel(x.to(torch.float32), ref_scales, ref_zero_points, axis=axis, dtype=q_dtype).int_repr()
+                torch.testing.assert_close(x_int8, x_q_int_repr, atol=1, rtol=100)
+
+                if device == 'cuda':
+                    trit_dynamic_quant = torch.compile(dynamically_quantize_per_channel, mode='max-autotune')
+                    trit_x_int8, trit_scales, trit_zps = trit_dynamic_quant(x, quant_min, quant_max, target_dtype, axis=axis)
+                    torch.testing.assert_close(trit_scales.to(torch.float32), ref_scales)
+                    torch.testing.assert_close(trit_zps, ref_zero_points, atol=0, rtol=0)
+                    torch.testing.assert_close(trit_x_int8, x_q_int_repr, atol=1, rtol=100)
+
+
+    def test_dynamically_quantize_per_channel_cuda_int8(self):
+            self._test_dynamically_quantize_per_channel_impl(
+                device = 'cuda', quant_min = -128, quant_max = 127, target_dtype = torch.int8
+            )
+
+    def test_dynamically_quantize_per_channel_cuda_uint8(self):
+        self._test_dynamically_quantize_per_channel_impl(
+           device = 'cuda', quant_min = 0, quant_max = 255, target_dtype = torch.uint8
+        )
+
+    def test_dynamically_quantize_per_channel_cpu_int8(self):
+            self._test_dynamically_quantize_per_channel_impl(
+                device = 'cpu', quant_min = -128, quant_max = 127, target_dtype = torch.int8
+            )
+
+    def test_dynamically_quantize_per_channel_cpu_uint8(self):
+        self._test_dynamically_quantize_per_channel_impl(
+           device = 'cpu', quant_min = 0, quant_max = 255, target_dtype = torch.uint8
+        )
 
 class TestPerTensorQuantization(unittest.TestCase):
     """ 
@@ -32,14 +96,14 @@ class TestPerTensorQuantization(unittest.TestCase):
                 x_q = torch.quantize_per_tensor_dynamic(x.to(torch.float32), dtype = q_dtype, reduce_range = False)
                 
                 torch.testing.assert_close(scale, x_q.q_scale())
-                torch.testing.assert_close(zero_point, x_q.q_zero_point())
+                torch.testing.assert_close(zero_point, x_q.q_zero_point(), atol=0, rtol=0)
                 torch.testing.assert_close(x_int8.to(torch.int32),x_q.int_repr().to(torch.int32), atol = tol, rtol = 100)
 
                 if device == 'cuda':
                     trit_dynamic_quant = torch.compile(dynamically_quantize_per_tensor, mode='max-autotune')
                     trit_x_int8, trit_scale, trit_zp = trit_dynamic_quant(x, quant_min, quant_max, target_dtype)
                     torch.testing.assert_close(trit_scale, x_q.q_scale())
-                    torch.testing.assert_close(trit_zp, x_q.q_zero_point())
+                    torch.testing.assert_close(trit_zp, x_q.q_zero_point(), atol=0, rtol=0)
                     torch.testing.assert_close(trit_x_int8.to(torch.int32),x_q.int_repr().to(torch.int32), atol = tol, rtol = 100)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #24
* #22
* #21
* __->__ #20

Summary: largely adapted from vkuzo's pytorch-labs/ao_benchmarks
quant_primitives, this function generalizes that function and fixes some
numerical issues. Specifically it allows for arbitrary channels and
calculates scale in the same way as dynamically_quantize_per_tensor
(i.e. with fp64 intermediates) in order to match the cuda reference
function. It also allows different dtypes other than int8.

triton graph of dynamically_quantize_per_channel:
https://gist.github.com/HDCharles/62ecd38aa852a8bc2b658277cf816307

Test Plan: python test_quant_primitives.py TestPerChannelQuantization

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D45757989](https://our.internmc.facebook.com/intern/diff/D45757989)