### PR TITLE
replace triton.ops dependency with fbgemm

### DIFF
--- a/protoquant/src/triton/matmul.py
+++ b/protoquant/src/triton/matmul.py
@@ -3,7 +3,10 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.ops.matmul_perf_model import early_config_prune, estimate_matmul_time
+from fbgemm_gpu.experimental.gemm.triton_gemm.matmul_perf_model import (
+    early_config_prune,
+    estimate_matmul_time,
+)
 
 
 def init_to_zero(name):


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/ao/pull/1236

X-link: https://github.com/fairinternal/xlformers/pull/11083

`triton.ops.matmul_perf_model` is moved to kernels directory with the 3.2 update. This change updates imports to be through `fbgemm_gpu.experimental.gemm.triton_gemm.matmul_perf_model`

Differential Revision: D65614265


